### PR TITLE
Adding auto-generated IDs to glossary

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -56,6 +56,7 @@ permalink: /reference/
 
 ## Glossary
 
+{:auto_ids}
 changeset
 :   A group of changes to one or more files
     that are [committed](#commit) to a [version control](#version-control) [repository](#repository)


### PR DESCRIPTION
The new version of Kramdown will add IDs to glossary entries (definition lists) if instructed to do so.
