### PR TITLE
Fix links to selenic.com

### DIFF
--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -61,7 +61,7 @@ across different computers facilitating collaboration among different people.
 > Automated version control systems are nothing new. Tools like RCS, CVS, or
 > Subversion are considered now legacy systems, offering more limited
 > capabilities than modern tools, such as
-> [Mercurial](http://mercurial.selenic.com/) and
+> [Mercurial](https://www.mercurial-scm.org/) and
 > [Git](http://swcarpentry.github.io/git-novice/).
 > In particular,
 > the latter are *distributed*, meaning that they don't need a centralized

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -20,7 +20,7 @@ file for editing with the command `hg config --edit`.
 
 If you want to know more about the many configuration options
 available you can use `hg help config` or visit [the Mercurial config
-documenttation](http://www.selenic.com/mercurial/hgrc.5.html).
+documenttation](https://www.selenic.com/mercurial/hgrc.5.html).
 
 One configuration option that can be useful is adding aliases.
 These are like shortcuts for longer `hg` commands.


### PR DESCRIPTION
The link in 01-basics was dead; the link in discuss worked, but https is
preferred.

Fixes #32.